### PR TITLE
Reduce allocations to improve speed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConvertBNG"
 uuid = "76c420ca-8e5d-4181-817d-b9cafca33221"
 authors = ["Joshua Nunn <joshuanunn@hotmail.co.uk>"]
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/ConvertBNG.jl
+++ b/src/ConvertBNG.jl
@@ -135,7 +135,7 @@ Perform Longitude, Latitude to ETRS89 conversion
     north = I + II * l ^ 2 + III * l ^ 4 + IIIA * l ^ 6
     east = E₀ + IV * l + V * l ^ 3 + VI * l ^ 5
 
-    return [east north]
+    return east, north
 end
 
 """
@@ -184,7 +184,7 @@ Note that either GRS80 or Airy 1830 ellipsoids can be passed
     ϕ = rad2deg(ϕ)
     λ = rad2deg(λ)
     λ, ϕ = round_to_eight(λ, ϕ)
-    return [λ ϕ]
+    return λ, ϕ
 end
 
 function convert_etrs89_to_ll(E::T, N::T) where {T<:Real}
@@ -207,7 +207,7 @@ function convert_osgb36(lonlat::Array{T,2}) where{T<:Real}
     en_arr = zeros(T, size(lonlat))
     # Transform
     Threads.@threads for i in 1:size(lonlat)[1]
-        en_arr[i,:] = convert_osgb36(lonlat[i,1], lonlat[i,2])
+        en_arr[i,:] .= convert_osgb36(lonlat[i,1], lonlat[i,2])
     end
     return en_arr
 end
@@ -220,7 +220,7 @@ function convert_osgb36_nothread(lonlat::Array{T,2}) where{T<:Real}
     en_arr = zeros(T, size(lonlat))
     # Transform
     for i in 1:size(lonlat)[1]
-        en_arr[i,:] = convert_osgb36(lonlat[i,1], lonlat[i,2])
+        en_arr[i,:] .= convert_osgb36(lonlat[i,1], lonlat[i,2])
     end
     return en_arr
 end
@@ -232,7 +232,7 @@ function convert_etrs89_to_osgb36(E::T, N::T) where {T<:Real}
     # Obtain OSTN15 corrections, and incorporate
     e_shift, n_shift, _ = ostn15_shifts(E, N)
     e_corr, n_corr = round_to_mm(E + e_shift, N + n_shift)
-    return [e_corr n_corr]
+    return e_corr, n_corr
 end
 
 """
@@ -250,7 +250,7 @@ function convert_osgb36_to_ll(en::Array{T,2}) where{T<:Real}
     ll_arr = zeros(T, size(en))
     # Transform
     Threads.@threads for i in 1:size(en)[1]
-        ll_arr[i,:] = convert_osgb36_to_ll(en[i,1], en[i,2])
+        ll_arr[i,:] .= convert_osgb36_to_ll(en[i,1], en[i,2])
     end
     return ll_arr
 end
@@ -263,7 +263,7 @@ function convert_osgb36_to_ll_nothread(en::Array{T,2}) where{T<:Real}
     ll_arr = zeros(T, size(en))
     # Transform
     for i in 1:size(en)[1]
-        ll_arr[i,:] = convert_osgb36_to_ll(en[i,1], en[i,2])
+        ll_arr[i,:] .= convert_osgb36_to_ll(en[i,1], en[i,2])
     end
     return ll_arr
 end
@@ -289,7 +289,7 @@ function convert_osgb36_to_etrs89(E::T, N::T) where {T<:Real}
     end
     x = E - dx
     y = N - dy
-    return [x y]
+    return x, y
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,11 @@ const PREC_FL = 0.000000001 # 10 dp for floating point comparison
 const AIRY_1830_SEMI_MAJOR = 6377563.396
 const AIRY_1830_SEMI_MINOR = 6356256.909
 
+approx(x, y, atol) = all(((xx, yy),) -> isapprox(xx, yy, atol=atol), zip(x, y))
+approx_ll(x, y) = approx(x, y, PREC_LL)
+approx_en(x, y) = approx(x, y, PREC_EN)
+approx_fl(x, y) = approx(x, y, PREC_FL)
+
 @testset "All tests" begin
 
     @testset "caister water tower" begin
@@ -17,19 +22,19 @@ const AIRY_1830_SEMI_MINOR = 6356256.909
         # ETRS89 eastings, northings: (651307.003, 313255.686)
         # Shifts eastings, northings: (102.801, -78.236)
         # OSGB36 eastings, northings: (651409.804, 313177.450)    
-        @test convert_etrs89_to_osgb36(651307.003, 313255.686) ≈ [651409.804 313177.450] atol=PREC_EN
-        @test convert_bng(1.716073973, 52.658007833) ≈ [651409.804 313177.450] atol=PREC_EN
-        @test convert_etrs89(1.716073973, 52.658007833) ≈ [651307.003 313255.686] atol=PREC_EN
-        @test convert_etrs89_to_ll(651307.003, 313255.686) ≈ [1.716073973 52.658007833] atol=PREC_LL
-        @test convert_lonlat(651409.804, 313177.450) ≈ [1.716073973 52.658007833] atol=PREC_LL
+        @test approx_en(convert_etrs89_to_osgb36(651307.003, 313255.686), (651409.804, 313177.450))
+        @test approx_en(convert_bng(1.716073973, 52.658007833), (651409.804, 313177.450))
+        @test approx_en(convert_etrs89(1.716073973, 52.658007833), (651307.003, 313255.686))
+        @test approx_ll(convert_etrs89_to_ll(651307.003, 313255.686), (1.716073973, 52.658007833))
+        @test approx_ll(convert_lonlat(651409.804, 313177.450), (1.716073973, 52.658007833))
         # Check OSTN15 shift retrival
-        @test collect(get_ostn_ref(651, 313)) ≈ [102.787, -78.242, 44.236] atol=PREC_FL
-        @test collect(ostn15_shifts(651307.003, 313255.686)) ≈ [102.800790098, -78.235984076, 44.228405219] atol=PREC_FL
+        @test approx_fl(get_ostn_ref(651, 313), (102.787, -78.242, 44.236))
+        @test approx_fl(ostn15_shifts(651307.003, 313255.686), (102.800790098, -78.235984076, 44.228405219))
         
         # From Transformations and OSGM15 User Guide - Annexe C
         # Caister Water Tower example
         # E,N to lon,lat using Airy 1830 ellipsoid
-        @test convert_to_ll(651409.903, 313177.270, AIRY_1830_SEMI_MAJOR, AIRY_1830_SEMI_MINOR) ≈ [1.717921583 52.65757031] atol=PREC_LL
+        @test approx_ll(convert_to_ll(651409.903, 313177.270, AIRY_1830_SEMI_MAJOR, AIRY_1830_SEMI_MINOR), (1.717921583, 52.65757031))
     end
 
     @testset "min/max bounds tests" begin
@@ -73,90 +78,101 @@ const AIRY_1830_SEMI_MINOR = 6356256.909
 
     @testset "OS latlon to OSGB36 testset" begin
         # TP01 to TP40
-        @test convert_bng(-6.299777520, 49.92226394) ≈ [  91492.146   11318.804] atol=PREC_EN
-        @test convert_bng(-5.203046100, 49.96006138) ≈ [ 170370.718   11572.405] atol=PREC_EN
-        @test convert_bng(-4.108645636, 50.43885826) ≈ [ 250359.811   62016.569] atol=PREC_EN
-        @test convert_bng(-1.297822772, 50.57563665) ≈ [ 449816.371   75335.861] atol=PREC_EN
-        @test convert_bng(-1.450514337, 50.93127938) ≈ [ 438710.920  114792.250] atol=PREC_EN
-        @test convert_bng(-3.551283492, 51.40078220) ≈ [ 292184.870  168003.465] atol=PREC_EN
-        @test convert_bng( 1.444547304, 51.37447026) ≈ [ 639821.835  169565.858] atol=PREC_EN
-        @test convert_bng(-2.544076183, 51.42754743) ≈ [ 362269.991  169978.690] atol=PREC_EN
-        @test convert_bng(-0.119925572, 51.48936565) ≈ [ 530624.974  178388.464] atol=PREC_EN
-        @test convert_bng(-4.308524770, 51.85890896) ≈ [ 241124.584  220332.641] atol=PREC_EN
-        @test convert_bng( 0.897243270, 51.89436637) ≈ [ 599445.590  225722.826] atol=PREC_EN
-        @test convert_bng(-2.154586144, 52.25529382) ≈ [ 389544.190  261912.153] atol=PREC_EN
-        @test convert_bng(-0.912489570, 52.25160951) ≈ [ 474335.969  262047.755] atol=PREC_EN
-        @test convert_bng( 0.401535471, 52.75136687) ≈ [ 562180.547  319784.995] atol=PREC_EN
-        @test convert_bng(-1.197476559, 52.96219109) ≈ [ 454002.834  340834.943] atol=PREC_EN
-        @test convert_bng(-2.640493208, 53.34480280) ≈ [ 357455.843  383290.436] atol=PREC_EN
-        @test convert_bng(-4.289180698, 53.41628516) ≈ [ 247958.971  393492.909] atol=PREC_EN
-        @test convert_bng(-4.289177929, 53.41630925) ≈ [ 247959.241  393495.583] atol=PREC_EN
-        @test convert_bng(-3.040454907, 53.77911026) ≈ [ 331534.564  431920.794] atol=PREC_EN
-        @test convert_bng(-1.663791682, 53.80021520) ≈ [ 422242.186  433818.701] atol=PREC_EN
-        @test convert_bng(-4.634521682, 54.08666318) ≈ [ 227778.330  468847.388] atol=PREC_EN
-        @test convert_bng(-0.077731332, 54.11685144) ≈ [ 525745.670  470703.214] atol=PREC_EN
-        @test convert_bng(-4.388491181, 54.32919541) ≈ [ 244780.636  495254.887] atol=PREC_EN
-        @test convert_bng(-2.938277411, 54.89542340) ≈ [ 339921.145  556034.761] atol=PREC_EN
-        @test convert_bng(-1.616576852, 54.97912274) ≈ [ 424639.355  565012.703] atol=PREC_EN
-        @test convert_bng(-4.296490163, 55.85399953) ≈ [ 256340.925  664697.269] atol=PREC_EN
-        @test convert_bng(-3.294792193, 55.92478266) ≈ [ 319188.434  670947.534] atol=PREC_EN
-        @test convert_bng(-5.828366919, 57.00606696) ≈ [ 167634.202  797067.144] atol=PREC_EN
-        @test convert_bng(-2.048560307, 57.13902519) ≈ [ 397160.491  805349.736] atol=PREC_EN
-        @test convert_bng(-4.219263986, 57.48625001) ≈ [ 267056.768  846176.972] atol=PREC_EN
-        @test convert_bng(-8.578544561, 57.81351838) ≈ [   9587.909  899448.996] atol=PREC_EN
-        @test convert_bng(-7.592555606, 58.21262247) ≈ [  71713.132  938516.404] atol=PREC_EN
-        @test convert_bng(-6.260914555, 58.51560361) ≈ [ 151968.652  966483.780] atol=PREC_EN
-        @test convert_bng(-3.726310221, 58.58120461) ≈ [ 299721.891  967202.992] atol=PREC_EN
-        @test convert_bng(-3.214540011, 59.03743871) ≈ [ 330398.323 1017347.016] atol=PREC_EN
-        @test convert_bng(-4.417576746, 59.09335035) ≈ [ 261596.778 1025447.602] atol=PREC_EN
-        @test convert_bng(-5.827993398, 59.09671617) ≈ [ 180862.461 1029604.114] atol=PREC_EN
-        @test convert_bng(-1.625169661, 59.53470794) ≈ [ 421300.525 1072147.239] atol=PREC_EN
-        @test convert_bng(-1.274869104, 59.85409914) ≈ [ 440725.073 1107878.448] atol=PREC_EN
-        @test convert_bng(-2.073828228, 60.13308092) ≈ [ 395999.668 1138728.951] atol=PREC_EN
+        @test approx_en(convert_bng(-6.299777520, 49.92226394),  (  91492.146,   11318.804))
+        @test approx_en(convert_bng(-5.203046100, 49.96006138),  ( 170370.718,   11572.405))
+        @test approx_en(convert_bng(-4.108645636, 50.43885826),  ( 250359.811,   62016.569))
+        @test approx_en(convert_bng(-1.297822772, 50.57563665),  ( 449816.371,   75335.861))
+        @test approx_en(convert_bng(-1.450514337, 50.93127938),  ( 438710.920,  114792.250))
+        @test approx_en(convert_bng(-3.551283492, 51.40078220),  ( 292184.870,  168003.465))
+        @test approx_en(convert_bng( 1.444547304, 51.37447026),  ( 639821.835,  169565.858))
+        @test approx_en(convert_bng(-2.544076183, 51.42754743),  ( 362269.991,  169978.690))
+        @test approx_en(convert_bng(-0.119925572, 51.48936565),  ( 530624.974,  178388.464))
+        @test approx_en(convert_bng(-4.308524770, 51.85890896),  ( 241124.584,  220332.641))
+        @test approx_en(convert_bng( 0.897243270, 51.89436637),  ( 599445.590,  225722.826))
+        @test approx_en(convert_bng(-2.154586144, 52.25529382),  ( 389544.190,  261912.153))
+        @test approx_en(convert_bng(-0.912489570, 52.25160951),  ( 474335.969,  262047.755))
+        @test approx_en(convert_bng( 0.401535471, 52.75136687),  ( 562180.547,  319784.995))
+        @test approx_en(convert_bng(-1.197476559, 52.96219109),  ( 454002.834,  340834.943))
+        @test approx_en(convert_bng(-2.640493208, 53.34480280),  ( 357455.843,  383290.436))
+        @test approx_en(convert_bng(-4.289180698, 53.41628516),  ( 247958.971,  393492.909))
+        @test approx_en(convert_bng(-4.289177929, 53.41630925),  ( 247959.241,  393495.583))
+        @test approx_en(convert_bng(-3.040454907, 53.77911026),  ( 331534.564,  431920.794))
+        @test approx_en(convert_bng(-1.663791682, 53.80021520),  ( 422242.186,  433818.701))
+        @test approx_en(convert_bng(-4.634521682, 54.08666318),  ( 227778.330,  468847.388))
+        @test approx_en(convert_bng(-0.077731332, 54.11685144),  ( 525745.670,  470703.214))
+        @test approx_en(convert_bng(-4.388491181, 54.32919541),  ( 244780.636,  495254.887))
+        @test approx_en(convert_bng(-2.938277411, 54.89542340),  ( 339921.145,  556034.761))
+        @test approx_en(convert_bng(-1.616576852, 54.97912274),  ( 424639.355,  565012.703))
+        @test approx_en(convert_bng(-4.296490163, 55.85399953),  ( 256340.925,  664697.269))
+        @test approx_en(convert_bng(-3.294792193, 55.92478266),  ( 319188.434,  670947.534))
+        @test approx_en(convert_bng(-5.828366919, 57.00606696),  ( 167634.202,  797067.144))
+        @test approx_en(convert_bng(-2.048560307, 57.13902519),  ( 397160.491,  805349.736))
+        @test approx_en(convert_bng(-4.219263986, 57.48625001),  ( 267056.768,  846176.972))
+        @test approx_en(convert_bng(-8.578544561, 57.81351838),  (   9587.909,  899448.996))
+        @test approx_en(convert_bng(-7.592555606, 58.21262247),  (  71713.132,  938516.404))
+        @test approx_en(convert_bng(-6.260914555, 58.51560361),  ( 151968.652,  966483.780))
+        @test approx_en(convert_bng(-3.726310221, 58.58120461),  ( 299721.891,  967202.992))
+        @test approx_en(convert_bng(-3.214540011, 59.03743871),  ( 330398.323, 1017347.016))
+        @test approx_en(convert_bng(-4.417576746, 59.09335035),  ( 261596.778, 1025447.602))
+        @test approx_en(convert_bng(-5.827993398, 59.09671617),  ( 180862.461, 1029604.114))
+        @test approx_en(convert_bng(-1.625169661, 59.53470794),  ( 421300.525, 1072147.239))
+        @test approx_en(convert_bng(-1.274869104, 59.85409914),  ( 440725.073, 1107878.448))
+        @test approx_en(convert_bng(-2.073828228, 60.13308092),  ( 395999.668, 1138728.951))
     end
 
     @testset "OS OSGB36 to latlon testset" begin
         # TP01 to TP40
-        @test convert_lonlat(  91492.146,   11318.804) ≈ [-6.299777520 49.92226394] atol=PREC_LL
-        @test convert_lonlat( 170370.718,   11572.405) ≈ [-5.203046100 49.96006138] atol=PREC_LL
-        @test convert_lonlat( 250359.811,   62016.569) ≈ [-4.108645636 50.43885826] atol=PREC_LL
-        @test convert_lonlat( 449816.371,   75335.861) ≈ [-1.297822772 50.57563665] atol=PREC_LL
-        @test convert_lonlat( 438710.920,  114792.250) ≈ [-1.450514337 50.93127938] atol=PREC_LL
-        @test convert_lonlat( 292184.870,  168003.465) ≈ [-3.551283492 51.40078220] atol=PREC_LL
-        @test convert_lonlat( 639821.835,  169565.858) ≈ [ 1.444547304 51.37447026] atol=PREC_LL
-        @test convert_lonlat( 362269.991,  169978.690) ≈ [-2.544076183 51.42754743] atol=PREC_LL
-        @test convert_lonlat( 530624.974,  178388.464) ≈ [-0.119925572 51.48936565] atol=PREC_LL
-        @test convert_lonlat( 241124.584,  220332.641) ≈ [-4.308524770 51.85890896] atol=PREC_LL
-        @test convert_lonlat( 599445.590,  225722.826) ≈ [ 0.897243270 51.89436637] atol=PREC_LL
-        @test convert_lonlat( 389544.190,  261912.153) ≈ [-2.154586144 52.25529382] atol=PREC_LL
-        @test convert_lonlat( 474335.969,  262047.755) ≈ [-0.912489570 52.25160951] atol=PREC_LL
-        @test convert_lonlat( 562180.547,  319784.995) ≈ [ 0.401535471 52.75136687] atol=PREC_LL
-        @test convert_lonlat( 454002.834,  340834.943) ≈ [-1.197476559 52.96219109] atol=PREC_LL
-        @test convert_lonlat( 357455.843,  383290.436) ≈ [-2.640493208 53.34480280] atol=PREC_LL
-        @test convert_lonlat( 247958.971,  393492.909) ≈ [-4.289180698 53.41628516] atol=PREC_LL
-        @test convert_lonlat( 247959.241,  393495.583) ≈ [-4.289177929 53.41630925] atol=PREC_LL
-        @test convert_lonlat( 331534.564,  431920.794) ≈ [-3.040454907 53.77911026] atol=PREC_LL
-        @test convert_lonlat( 422242.186,  433818.701) ≈ [-1.663791682 53.80021520] atol=PREC_LL
-        @test convert_lonlat( 227778.330,  468847.388) ≈ [-4.634521682 54.08666318] atol=PREC_LL
-        @test convert_lonlat( 525745.670,  470703.214) ≈ [-0.077731332 54.11685144] atol=PREC_LL
-        @test convert_lonlat( 244780.636,  495254.887) ≈ [-4.388491181 54.32919541] atol=PREC_LL
-        @test convert_lonlat( 339921.145,  556034.761) ≈ [-2.938277411 54.89542340] atol=PREC_LL
-        @test convert_lonlat( 424639.355,  565012.703) ≈ [-1.616576852 54.97912274] atol=PREC_LL
-        @test convert_lonlat( 256340.925,  664697.269) ≈ [-4.296490163 55.85399953] atol=PREC_LL
-        @test convert_lonlat( 319188.434,  670947.534) ≈ [-3.294792193 55.92478266] atol=PREC_LL
-        @test convert_lonlat( 167634.202,  797067.144) ≈ [-5.828366919 57.00606696] atol=PREC_LL
-        @test convert_lonlat( 397160.491,  805349.736) ≈ [-2.048560307 57.13902519] atol=PREC_LL
-        @test convert_lonlat( 267056.768,  846176.972) ≈ [-4.219263986 57.48625001] atol=PREC_LL
-        @test convert_lonlat(   9587.909,  899448.996) ≈ [-8.578544561 57.81351838] atol=PREC_LL
-        @test convert_lonlat(  71713.132,  938516.404) ≈ [-7.592555606 58.21262247] atol=PREC_LL
-        @test convert_lonlat( 151968.652,  966483.780) ≈ [-6.260914555 58.51560361] atol=PREC_LL
-        @test convert_lonlat( 299721.891,  967202.992) ≈ [-3.726310221 58.58120461] atol=PREC_LL
-        @test convert_lonlat( 330398.323, 1017347.016) ≈ [-3.214540011 59.03743871] atol=PREC_LL
-        @test convert_lonlat( 261596.778, 1025447.602) ≈ [-4.417576746 59.09335035] atol=PREC_LL
-        @test convert_lonlat( 180862.461, 1029604.114) ≈ [-5.827993398 59.09671617] atol=PREC_LL
-        @test convert_lonlat( 421300.525, 1072147.239) ≈ [-1.625169661 59.53470794] atol=PREC_LL
-        @test convert_lonlat( 440725.073, 1107878.448) ≈ [-1.274869104 59.85409914] atol=PREC_LL
-        @test convert_lonlat( 395999.668, 1138728.951) ≈ [-2.073828228 60.13308092] atol=PREC_LL
+        @test approx_ll(convert_lonlat(  91492.146,   11318.804), (-6.299777520, 49.92226394))
+        @test approx_ll(convert_lonlat( 170370.718,   11572.405), (-5.203046100, 49.96006138))
+        @test approx_ll(convert_lonlat( 250359.811,   62016.569), (-4.108645636, 50.43885826))
+        @test approx_ll(convert_lonlat( 449816.371,   75335.861), (-1.297822772, 50.57563665))
+        @test approx_ll(convert_lonlat( 438710.920,  114792.250), (-1.450514337, 50.93127938))
+        @test approx_ll(convert_lonlat( 292184.870,  168003.465), (-3.551283492, 51.40078220))
+        @test approx_ll(convert_lonlat( 639821.835,  169565.858), ( 1.444547304, 51.37447026))
+        @test approx_ll(convert_lonlat( 362269.991,  169978.690), (-2.544076183, 51.42754743))
+        @test approx_ll(convert_lonlat( 530624.974,  178388.464), (-0.119925572, 51.48936565))
+        @test approx_ll(convert_lonlat( 241124.584,  220332.641), (-4.308524770, 51.85890896))
+        @test approx_ll(convert_lonlat( 599445.590,  225722.826), ( 0.897243270, 51.89436637))
+        @test approx_ll(convert_lonlat( 389544.190,  261912.153), (-2.154586144, 52.25529382))
+        @test approx_ll(convert_lonlat( 474335.969,  262047.755), (-0.912489570, 52.25160951))
+        @test approx_ll(convert_lonlat( 562180.547,  319784.995), ( 0.401535471, 52.75136687))
+        @test approx_ll(convert_lonlat( 454002.834,  340834.943), (-1.197476559, 52.96219109))
+        @test approx_ll(convert_lonlat( 357455.843,  383290.436), (-2.640493208, 53.34480280))
+        @test approx_ll(convert_lonlat( 247958.971,  393492.909), (-4.289180698, 53.41628516))
+        @test approx_ll(convert_lonlat( 247959.241,  393495.583), (-4.289177929, 53.41630925))
+        @test approx_ll(convert_lonlat( 331534.564,  431920.794), (-3.040454907, 53.77911026))
+        @test approx_ll(convert_lonlat( 422242.186,  433818.701), (-1.663791682, 53.80021520))
+        @test approx_ll(convert_lonlat( 227778.330,  468847.388), (-4.634521682, 54.08666318))
+        @test approx_ll(convert_lonlat( 525745.670,  470703.214), (-0.077731332, 54.11685144))
+        @test approx_ll(convert_lonlat( 244780.636,  495254.887), (-4.388491181, 54.32919541))
+        @test approx_ll(convert_lonlat( 339921.145,  556034.761), (-2.938277411, 54.89542340))
+        @test approx_ll(convert_lonlat( 424639.355,  565012.703), (-1.616576852, 54.97912274))
+        @test approx_ll(convert_lonlat( 256340.925,  664697.269), (-4.296490163, 55.85399953))
+        @test approx_ll(convert_lonlat( 319188.434,  670947.534), (-3.294792193, 55.92478266))
+        @test approx_ll(convert_lonlat( 167634.202,  797067.144), (-5.828366919, 57.00606696))
+        @test approx_ll(convert_lonlat( 397160.491,  805349.736), (-2.048560307, 57.13902519))
+        @test approx_ll(convert_lonlat( 267056.768,  846176.972), (-4.219263986, 57.48625001))
+        @test approx_ll(convert_lonlat(   9587.909,  899448.996), (-8.578544561, 57.81351838))
+        @test approx_ll(convert_lonlat(  71713.132,  938516.404), (-7.592555606, 58.21262247))
+        @test approx_ll(convert_lonlat( 151968.652,  966483.780), (-6.260914555, 58.51560361))
+        @test approx_ll(convert_lonlat( 299721.891,  967202.992), (-3.726310221, 58.58120461))
+        @test approx_ll(convert_lonlat( 330398.323, 1017347.016), (-3.214540011, 59.03743871))
+        @test approx_ll(convert_lonlat( 261596.778, 1025447.602), (-4.417576746, 59.09335035))
+        @test approx_ll(convert_lonlat( 180862.461, 1029604.114), (-5.827993398, 59.09671617))
+        @test approx_ll(convert_lonlat( 421300.525, 1072147.239), (-1.625169661, 59.53470794))
+        @test approx_ll(convert_lonlat( 440725.073, 1107878.448), (-1.274869104, 59.85409914))
+        @test approx_ll(convert_lonlat( 395999.668, 1138728.951), (-2.073828228, 60.1330809281))
+    end
+
+    @testset "Array input-output" begin
+        # Check results from single- and multiple-point methods are the same
+        let n = 100, lons = 5.0.*(rand(n) .- 0.5), lats = 55 .+ 5.0.*rand(n)
+            en = vcat([hcat(convert_bng(lon, lat)...) for (lon, lat) in zip(lons, lats)]...)
+            # Broadcast identity comparison to check NaNs are the same
+            @test all(convert_bng(hcat(lons, lats)) .=== en)
+            ll = vcat([hcat(convert_lonlat(east, north)...) for (east, north) in eachrow(en)]...)
+            @test all(convert_lonlat(en) .=== ll)
+        end
     end
 
 end


### PR DESCRIPTION
- Return tuples instead of 1x2 arrays in internal functions
- Return a tuple instead of a 1x2 array for public-facing functions
  when called with a single point
- Add tests for the equivalence of calling the single-point methods
  multiple times, and calling the multiple-point methods once
- Bump minor version number since the API is changed for the
  single-point methods (these now return tuples):
  - convert_bng(lon, lat)
  - convert_lonlat(E, N)

These changes appear to offer a 15-20% increase in speed.